### PR TITLE
Add Gemini API key config and update roadmap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 DISCORD_TOKEN=your_token_here
+GEMINI_API_KEY=your_gemini_key_here

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Chatbot de jeu post-apocalyptique pour Discord.
 
 ## Installation
 
-1. Créez un fichier `.env` à partir de `.env.example` et renseignez votre `DISCORD_TOKEN`.
+1. Créez un fichier `.env` à partir de `.env.example` et renseignez votre `DISCORD_TOKEN` et votre `GEMINI_API_KEY`.
 2. Installez les dépendances :
    ```bash
    pip install -r requirements.txt

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@
 ## 🎯 Phase 1 : Infrastructure Core (Semaine 1)
 
 ### 1.1 Configuration et environnement
-- [ ] Ajouter `GEMINI_API_KEY` dans `.env.example`
+- [x] Ajouter `GEMINI_API_KEY` dans `.env.example`
 - [ ] Mettre à jour `requirements.txt` avec :
   ```
   google-generativeai>=0.3.0


### PR DESCRIPTION
## Summary
- add GEMINI_API_KEY placeholder to .env example
- document GEMINI_API_KEY in README
- start roadmap by marking GEMINI_API_KEY step done

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ab4dd20fd8832d96999ba41c3d2b4d